### PR TITLE
get an active customers products that aren't on an order

### DIFF
--- a/src/Bangazon/Managers/ProductManager.cs
+++ b/src/Bangazon/Managers/ProductManager.cs
@@ -79,6 +79,23 @@ namespace BangazonCLI.Managers
             _db.Delete($"DELETE from product  where product.productId={productId}");
             return true;
         }
+        public List<Product> getActiveCustomersNonOrderProdcuts(int activeCustomer)
+        {
+            _db.Query($"select product.price, product.title, product.description,product.productid, product.sellerID, product.quantityavailable from product where product.productid not in (select orderproduct.productID from orderproduct) and product.sellerID= {activeCustomer}",
+                (SqliteDataReader reader) => {
+                    _products.Clear();
+                    while (reader.Read ())
+                    {
+                        _products.Add(new Product(
+                            reader.GetInt32(0),
+                            reader[1].ToString()
+                        ));
+                    }
+                }
+            );
+
+            return _products;
+        }
 
         public List<Product> GetListOfProducts()
         {

--- a/test/Bangazon.Tests/Bangazon_ProductManagerShould.cs
+++ b/test/Bangazon.Tests/Bangazon_ProductManagerShould.cs
@@ -86,6 +86,16 @@ namespace Bangazon.Tests
             var result= _productManager.deleteProduct(productThatWasCreated);
             Assert.True(result);
         }
+        [Fact]
+        public void getActiveCustomersNonOrderProductsToThenSelectToDeleteFromTheSystem()
+        {
+            Product product1 = new Product(1, "Blue Rug", 5, "Awesome blue rug", 130.05f, 1);
+            Product product2 = new Product(1, "Rug", 5, "Awesome shag rug - 8x10", 125.99f, 1);
+            int product1ThatWasCreated = _productManager.CreateProduct(product1);
+            int product2ThatWasCreated = _productManager.CreateProduct(product2);
+            List<Product> listofProducts = _productManager.getActiveCustomersNonOrderProdcuts(product1ThatWasCreated);
+            Assert.IsType<List<Product>>(listofProducts);
+        }
 
         public void Dispose()
         {


### PR DESCRIPTION
## Fixes #7 #76 .

## Changes proposed in this pull request: 
- method for getting active customers products that aren't on an order
- testing for the method


## How to test: 
- go to productManagerShould 
- run test for "getActiveCustomersNonOrderProductsToThenSelectToDeleteFromTheSystem"


@EnRonSwanson/
