### PR TITLE
90 day old order works?

### DIFF
--- a/src/Bangazon/Managers/ProductManager.cs
+++ b/src/Bangazon/Managers/ProductManager.cs
@@ -114,6 +114,23 @@ namespace BangazonCLI.Managers
 
             return _products;
         }
+        public List<Product> getNinetyDayOldOrderProducts()
+        {
+            _db.Query("select distinct orderproduct.productID, [order].datecreated from orderproduct join product on product.productid= orderproduct.productID join [order] on [order].orderid = orderproduct.orderID where [order].datecreated < date('now', '-90 day') and [order].paymenttypeID is null;",
+                (SqliteDataReader reader) => {
+                    _products.Clear();
+                    while (reader.Read ())
+                    {
+                        _products.Add(new Product(
+                            reader.GetInt32(0),
+                            reader[1].ToString()
+                        ));
+                    }
+                }
+            );
+
+            return _products;
+        }
 
     }
 }

--- a/test/Bangazon.Tests/Bangazon_ProductManagerShould.cs
+++ b/test/Bangazon.Tests/Bangazon_ProductManagerShould.cs
@@ -96,6 +96,16 @@ namespace Bangazon.Tests
             List<Product> listofProducts = _productManager.getActiveCustomersNonOrderProdcuts(product1ThatWasCreated);
             Assert.IsType<List<Product>>(listofProducts);
         }
+        [Fact]
+        public void getStaleProductsThatHaveBeenAddedToAnOrderAndAreAlso90DaysOld()
+        {
+            Product product1 = new Product(1, "Blue Rug", 5, "Awesome blue rug", 130.05f, 1);
+            Product product2 = new Product(1, "Rug", 5, "Awesome shag rug - 8x10", 125.99f, 1);
+            int product1ThatWasCreated = _productManager.CreateProduct(product1);
+            int product2ThatWasCreated = _productManager.CreateProduct(product2);
+            List<Product> listofProducts = _productManager.getNinetyDayOldOrderProducts();
+            Assert.IsType<List<Product>>(listofProducts);
+        }
 
         public void Dispose()
         {


### PR DESCRIPTION
## Fixes #9 #81 .

## Changes proposed in this pull request: 
- method for getting a product that is on an order, is not completed, and order is 90 days old
- testing for above method

## How to test: 
- go to productManagerShould
- run test for "getStaleProductsThatHaveBeenAddedToAnOrderAndAreAlso90DaysOld"

@EnRonSwanson/
