### PR TITLE
active customer can now NOT buy any of their products

### DIFF
--- a/src/Bangazon/Managers/ProductManager.cs
+++ b/src/Bangazon/Managers/ProductManager.cs
@@ -101,9 +101,9 @@ namespace BangazonCLI.Managers
             return _products;
         }
 
-        public List<Product> GetListOfProducts()
+        public List<Product> GetListOfProducts(int activeId)
         {
-            _db.Query("select productid, title from product",
+            _db.Query($"select productid, title from product where product.sellerId != {activeId}",
                 (SqliteDataReader reader) => {
                     _products.Clear();
                     while (reader.Read ())

--- a/src/Bangazon/Program.cs
+++ b/src/Bangazon/Program.cs
@@ -14,7 +14,7 @@ namespace BangazonCLI
     {
         public static void Main(string[] args)
         {
-            var db = new DatabaseInterface("BANGAZON_CLI_DB");
+        var db = new DatabaseInterface("BANGAZON_CLI_DB"); 
             ActiveCustomer activeCustomer = new ActiveCustomer();
             ProductManager productManager = new ProductManager(db);
             PaymentTypeManager payment= new PaymentTypeManager(db);
@@ -152,8 +152,9 @@ namespace BangazonCLI
 
                 if (choice == 5)
                     {
+                        int buyerId= ActiveCustomer.activeCustomerId;
                         Console.WriteLine("*********************");
-                        List<Product> productList = productManager.GetListOfProducts();
+                        List<Product> productList = productManager.GetListOfProducts(buyerId);
                         int? activeOrder = orderManager.CreateOrder();
                         if(activeOrder != null)
                         {

--- a/test/Bangazon.Tests/Bangazon_ProductManagerShould.cs
+++ b/test/Bangazon.Tests/Bangazon_ProductManagerShould.cs
@@ -70,7 +70,7 @@ namespace Bangazon.Tests
             Product product2 = new Product(1, "Rug", 5, "Awesome shag rug - 8x10", 125.99f, 1);
             int product1ThatWasCreated = _productManager.CreateProduct(product1);
             int product2ThatWasCreated = _productManager.CreateProduct(product2);
-            List<Product> listofProducts = _productManager.GetListOfProducts();
+            List<Product> listofProducts = _productManager.GetListOfProducts(1);
             Assert.IsType<List<Product>>(listofProducts);
         }
         


### PR DESCRIPTION
## Fixes #5 #63 .

## Changes proposed in this pull request: 
- Active customer cannot add their own product to an order
- changed sql query in productManager
- modified the program.cs to pass in an active customer

## How to test: 
- dotnet run / set active customer
- choose option 5, and make sure in db browser that their products aren't showing up to add


@EnRonSwanson/
